### PR TITLE
fix: remove machine_address service config by querying FQDN through app client

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,26 +83,24 @@ Send images to Viam for [analytics and machine learning model training](https://
 
 Get [a list of classifications](https://docs.viam.com/services/vision/classification/) from an image.
 
-| Parameter         | Description                                                                                                      |
-| ----------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `classifier_name` | Name of classifier vision service configured in Viam.                                                            |
-| `confidence`      | Threshold for filtering results returned by the service.                                                         |
-| `count`           | Number of classifications to return from the service.                                                            |
-| `robot_address`   | If authenticated using the Org API key, provide the robot address associated with the configured vision service. |
-| `filepath`        | Local file path to the image to be analyzed.                                                                     |
-| `camera`          | The camera entity from which an image is captured and analyzed.                                                  |
+| Parameter         | Description                                                     |
+| ----------------- | --------------------------------------------------------------- |
+| `classifier_name` | Name of classifier vision service configured in Viam.           |
+| `confidence`      | Threshold for filtering results returned by the service.        |
+| `count`           | Number of classifications to return from the service.           |
+| `filepath`        | Local file path to the image to be analyzed.                    |
+| `camera`          | The camera entity from which an image is captured and analyzed. |
 
 ### viam.get_detections
 
 Get [a list of detected objects](https://docs.viam.com/services/vision/detection/) from an image.
 
-| Parameter       | Description                                                                                                      |
-| --------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `detector_name` | Name of detection vision service configured in Viam.                                                             |
-| `confidence`    | Threshold for filtering results returned by the service.                                                         |
-| `robot_address` | If authenticated using the Org API key, provide the robot address associated with the configured vision service. |
-| `filepath`      | Local file path to the image to be analyzed.                                                                     |
-| `camera`        | The camera entity from which an image is captured and analyzed.                                                  |
+| Parameter       | Description                                                     |
+| --------------- | --------------------------------------------------------------- |
+| `detector_name` | Name of detection vision service configured in Viam.            |
+| `confidence`    | Threshold for filtering results returned by the service.        |
+| `filepath`      | Local file path to the image to be analyzed.                    |
+| `camera`        | The camera entity from which an image is captured and analyzed. |
 
 <!---->
 

--- a/custom_components/viam/manager.py
+++ b/custom_components/viam/manager.py
@@ -31,39 +31,42 @@ class ViamManager:
         data: dict[str, Any],
     ) -> None:
         """Store initialized client and user input data."""
+        self.api_key: str = data.get(CONF_API_KEY, "")
         self.api_key_id: str = data.get(CONF_API_ID, "")
         self.entry_id = entry_id
         self.hass = hass
         self.machine_id: str = data.get(CONF_MACHINE_ID, "")
-        self.api_key: str = data.get(CONF_API_KEY, "")
         self.viam = viam
 
     def unload(self) -> None:
         """Clean up any open clients."""
         self.viam.close()
 
-    async def get_robot_client(self, machine_address: str | None) -> RobotClient:
+    async def get_robot_client(self) -> RobotClient:
         """Check initialized data to create robot client."""
-        payload = self.api_key
-        auth_entity: str | None = self.api_key_id
+        api_key = self.api_key
+        api_key_id = self.api_key_id
+
+        machine = next(iter(await self.get_machine_parts()))
+        machine_address = machine.fqdn
 
         if machine_address is None:
             raise ServiceValidationError(
-                "The machine address is required for this connection type.",
+                "The machine address could not be found. It may be offline.",
                 translation_domain=DOMAIN,
                 translation_key="machine_credentials_required",
             )
 
-        if payload is None:
+        if api_key is None:
             raise ServiceValidationError(
                 "The necessary credentials for connecting to the machine could not be found.",
                 translation_domain=DOMAIN,
                 translation_key="machine_credentials_not_found",
             )
 
-        robot_options = RobotClient.Options.with_api_key(payload, auth_entity)
+        robot_options = RobotClient.Options.with_api_key(api_key, api_key_id)
         return await RobotClient.at_address(machine_address, robot_options)
 
-    async def get_robot_parts(self) -> list[RobotPart]:
+    async def get_machine_parts(self) -> list[RobotPart]:
         """Retrieve list of robot parts."""
         return await self.viam.app_client.get_robot_parts(robot_id=self.machine_id)

--- a/custom_components/viam/manifest.json
+++ b/custom_components/viam/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/HipsterBrown/viam-home-assistant-integration/issues",
   "requirements": ["viam-sdk==0.25.2"],
-  "version": "0.1.1"
+  "version": "0.1.2"
 }

--- a/custom_components/viam/services.py
+++ b/custom_components/viam/services.py
@@ -41,7 +41,6 @@ SERVICE_COMPONENT_TYPE = "component_type"
 SERVICE_FILEPATH = "filepath"
 SERVICE_CAMERA = "camera"
 SERVICE_CONFIDENCE = "confidence_threshold"
-SERVICE_MACHINE_ADDRESS = "machine_address"
 SERVICE_FILE_NAME = "file_name"
 SERVICE_CLASSIFIER_NAME = "classifier_name"
 SERVICE_COUNT = "count"
@@ -75,7 +74,6 @@ VISION_SERVICE_FIELDS = IMAGE_SERVICE_FIELDS.extend(
         vol.Optional(SERVICE_CONFIDENCE, default="0.6"): vol.All(
             str, vol.Coerce(float), vol.Range(min=0, max=1)
         ),
-        vol.Required(SERVICE_MACHINE_ADDRESS): vol.All(str),
     }
 )
 
@@ -165,7 +163,7 @@ def __get_manager(hass: HomeAssistant, call: ServiceCall) -> ViamManager:
 async def __capture_data(hass: HomeAssistant, call: ServiceCall) -> None:
     """Accept input from service call to send to Viam."""
     manager = __get_manager(hass, call)
-    parts: list[RobotPart] = await manager.get_robot_parts()
+    parts: list[RobotPart] = await manager.get_machine_parts()
     values = [call.data.get(SERVICE_VALUES, {})]
     component_type = call.data.get(SERVICE_COMPONENT_TYPE, "sensor")
     component_name = call.data.get(SERVICE_COMPONENT_NAME, "")
@@ -183,7 +181,7 @@ async def __capture_data(hass: HomeAssistant, call: ServiceCall) -> None:
 async def __capture_image(hass: HomeAssistant, call: ServiceCall) -> None:
     """Accept input from service call to send to Viam."""
     manager = __get_manager(hass, call)
-    parts: list[RobotPart] = await manager.get_robot_parts()
+    parts: list[RobotPart] = await manager.get_machine_parts()
     filepath = call.data.get(SERVICE_FILEPATH)
     camera_entity = call.data.get(SERVICE_CAMERA)
     component_name = call.data.get(SERVICE_COMPONENT_NAME)
@@ -219,9 +217,7 @@ async def __get_service_values(
     count = int(call.data.get(SERVICE_COUNT, 2))
     confidence_threshold = float(call.data.get(SERVICE_CONFIDENCE, 0.6))
 
-    async with await manager.get_robot_client(
-        call.data.get(SERVICE_MACHINE_ADDRESS)
-    ) as robot:
+    async with await manager.get_robot_client() as robot:
         service: VisionClient = VisionClient.from_robot(robot, service_name)
         image = await __get_image(hass, filepath, camera_entity)
 

--- a/custom_components/viam/services.yaml
+++ b/custom_components/viam/services.yaml
@@ -48,10 +48,6 @@ get_classifications:
       required: false
       selector:
         number:
-    machine_address:
-      required: true
-      selector:
-        text:
     filepath:
       required: false
       selector:
@@ -74,10 +70,6 @@ get_detections:
       selector:
         text:
           type: number
-    machine_address:
-      required: true
-      selector:
-        text:
     filepath:
       required: false
       selector:

--- a/custom_components/viam/strings.json
+++ b/custom_components/viam/strings.json
@@ -49,7 +49,7 @@
       "message": "Invalid config entry provided. {config_entry} is not loaded."
     },
     "machine_credentials_required": {
-      "message": "The machine address is required for this connection type."
+      "message": "The machine address could not be found. It may be offline."
     },
     "machine_credentials_not_found": {
       "message": "The necessary credentials for connecting to the machine could not be found."
@@ -112,10 +112,6 @@
           "name": "Classification count",
           "description": "Number of classifications to return from the service"
         },
-        "machine_address": {
-          "name": "Machine address",
-          "description": "Provide the machine address associated with the configured vision service."
-        },
         "filepath": {
           "name": "Filepath",
           "description": "Local file path to the image you wish to reference."
@@ -137,10 +133,6 @@
         "confidence": {
           "name": "Confidence",
           "description": "Threshold for filtering results returned by the service"
-        },
-        "machine_address": {
-          "name": "Machine address",
-          "description": "Provide the machine address associated with the configured vision service."
         },
         "filepath": {
           "name": "Filepath",

--- a/custom_components/viam/translations/en.json
+++ b/custom_components/viam/translations/en.json
@@ -49,7 +49,7 @@
       "message": "The necessary credentials for connecting to the machine could not be found."
     },
     "machine_credentials_required": {
-      "message": "The machine address is required for this connection type."
+      "message": "The machine address could not be found. It may be offline."
     },
     "unloaded_config_entry": {
       "message": "Invalid config entry provided. {config_entry} is not loaded."
@@ -152,10 +152,6 @@
         "filepath": {
           "description": "Local file path to the image you wish to reference.",
           "name": "Filepath"
-        },
-        "machine_address": {
-          "description": "Provide the machine address associated with the configured vision service.",
-          "name": "Machine Address"
         }
       },
       "name": "Classify Images"
@@ -178,10 +174,6 @@
         "filepath": {
           "description": "Local file path to the image you wish to reference.",
           "name": "Filepath"
-        },
-        "machine_address": {
-          "description": "Provide the machine address associated with the configured vision service.",
-          "name": "Machine Address"
         }
       },
       "name": "Detect Objects in Images"


### PR DESCRIPTION
While working on the announcement blog post for this integration, I realized that it's possible to look up the machine address (or full qualified domain name FQDN) through the existing ViamClient connection. This reduces the amount of required fields for setting up the object detections and image classification services to one, the vision service name (this could eventually be made optional by looking at the configured services on a machine and using the first one based on the assumption that most machines will only have one). 