### PR TITLE
fix: add missing config_entry selector field to services

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Send arbitrary tabular data to Viam to [view and analyze](https://docs.viam.com/
 
 | Parameter        | Description                                                            |
 | ---------------- | ---------------------------------------------------------------------- |
+| `config_entry`   | Viam machine to associate with the service.                            |
 | `values`         | List of data objects to send to Viam.                                  |
 | `component_name` | Name of the sensor or other component to which the data is associated. |
 | `component_type` | Type of the sensor or other component to which the data is associated. |
@@ -74,6 +75,7 @@ Send images to Viam for [analytics and machine learning model training](https://
 
 | Parameter        | Description                                                              |
 | ---------------- | ------------------------------------------------------------------------ |
+| `config_entry`   | Viam machine to associate with the service.                              |
 | `filepath`       | Local file path to the image to be uploaded.                             |
 | `camera`         | The camera entity from which an image is captured.                       |
 | `file_name`      | The name of the file that will be displayed in the metadata within Viam. |
@@ -85,6 +87,7 @@ Get [a list of classifications](https://docs.viam.com/services/vision/classifica
 
 | Parameter         | Description                                                     |
 | ----------------- | --------------------------------------------------------------- |
+| `config_entry`    | Viam machine to associate with the service.                     |
 | `classifier_name` | Name of classifier vision service configured in Viam.           |
 | `confidence`      | Threshold for filtering results returned by the service.        |
 | `count`           | Number of classifications to return from the service.           |
@@ -97,6 +100,7 @@ Get [a list of detected objects](https://docs.viam.com/services/vision/detection
 
 | Parameter       | Description                                                     |
 | --------------- | --------------------------------------------------------------- |
+| `config_entry`  | Viam machine to associate with the service.                     |
 | `detector_name` | Name of detection vision service configured in Viam.            |
 | `confidence`    | Threshold for filtering results returned by the service.        |
 | `filepath`      | Local file path to the image to be analyzed.                    |

--- a/custom_components/viam/manifest.json
+++ b/custom_components/viam/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/HipsterBrown/viam-home-assistant-integration/issues",
   "requirements": ["viam-sdk==0.25.2"],
-  "version": "0.1.3"
+  "version": "0.1.4"
 }

--- a/custom_components/viam/services.yaml
+++ b/custom_components/viam/services.yaml
@@ -1,5 +1,10 @@
 capture_data:
   fields:
+    config_entry:
+      required: true
+      selector:
+        config_entry:
+          integration: viam
     values:
       required: true
       selector:
@@ -14,6 +19,11 @@ capture_data:
         text:
 capture_image:
   fields:
+    config_entry:
+      required: true
+      selector:
+        config_entry:
+          integration: viam
     filepath:
       required: false
       selector:
@@ -34,6 +44,11 @@ capture_image:
         text:
 get_classifications:
   fields:
+    config_entry:
+      required: true
+      selector:
+        config_entry:
+          integration: viam
     classifier_name:
       required: true
       selector:
@@ -60,6 +75,11 @@ get_classifications:
             domain: camera
 get_detections:
   fields:
+    config_entry:
+      required: true
+      selector:
+        config_entry:
+          integration: viam
     detector_name:
       required: true
       selector:

--- a/custom_components/viam/strings.json
+++ b/custom_components/viam/strings.json
@@ -60,6 +60,10 @@
       "name": "Capture data",
       "description": "Send arbitrary tabular data to Viam for analytics and model training.",
       "fields": {
+        "config_entry": {
+          "name": "Viam machine",
+          "description": "The Viam machine to associate with this service."
+        },
         "values": {
           "name": "Values",
           "description": "List of tabular data to send to Viam."
@@ -78,6 +82,10 @@
       "name": "Capture image",
       "description": "Send images to Viam for analytics and model training.",
       "fields": {
+        "config_entry": {
+          "name": "Viam machine",
+          "description": "The Viam machine to associate with this service."
+        },
         "filepath": {
           "name": "Filepath",
           "description": "Local file path to the image you wish to reference."
@@ -100,6 +108,10 @@
       "name": "Classify images",
       "description": "Get a list of classifications from an image.",
       "fields": {
+        "config_entry": {
+          "name": "Viam machine",
+          "description": "The Viam machine to associate with this service."
+        },
         "classifier_name": {
           "name": "Classifier name",
           "description": "Name of classifier vision service configured in Viam"
@@ -126,6 +138,10 @@
       "name": "Detect objects in images",
       "description": "Get a list of detected objects from an image.",
       "fields": {
+        "config_entry": {
+          "name": "Viam machine",
+          "description": "The Viam machine to associate with this service."
+        },
         "detector_name": {
           "name": "Detector name",
           "description": "Name of detector vision service configured in Viam"

--- a/custom_components/viam/translations/en.json
+++ b/custom_components/viam/translations/en.json
@@ -67,6 +67,10 @@
           "description": "The type of the associated component.",
           "name": "Component Type"
         },
+        "config_entry": {
+          "name": "Viam machine",
+          "description": "The Viam machine to associate with this service."
+        },
         "values": {
           "description": "List of tabular data to send to Viam.",
           "name": "Values"
@@ -84,6 +88,10 @@
         "component_name": {
           "description": "The name of the configured machine component to use.",
           "name": "Component Name"
+        },
+        "config_entry": {
+          "name": "Viam machine",
+          "description": "The Viam machine to associate with this service."
         },
         "file_name": {
           "description": "The name of the file that will be displayed in the metadata within Viam.",
@@ -110,6 +118,10 @@
         "component_type": {
           "description": "The type of the associated component.",
           "name": "Component Type"
+        },
+        "config_entry": {
+          "name": "Viam machine",
+          "description": "The Viam machine to associate with this service."
         },
         "confidence": {
           "description": "Threshold for filtering results returned by the service",
@@ -145,6 +157,10 @@
           "description": "Threshold for filtering results returned by the service",
           "name": "Confidence"
         },
+        "config_entry": {
+          "name": "Viam machine",
+          "description": "The Viam machine to associate with this service."
+        },
         "count": {
           "description": "Number of classifications to return from the service",
           "name": "Classification count"
@@ -166,6 +182,10 @@
         "confidence": {
           "description": "Threshold for filtering results returned by the service",
           "name": "Confidence"
+        },
+        "config_entry": {
+          "name": "Viam machine",
+          "description": "The Viam machine to associate with this service."
         },
         "detector_name": {
           "description": "Name of detector vision service configured in Viam",


### PR DESCRIPTION
The `config_entry` field was required but was missing from the available service fields from which to select the associated Viam configuration. This adds the expected selector and strings to display the field. 